### PR TITLE
Typehint fix for replaceMatches

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1200,7 +1200,7 @@ class Str
      * Replace the patterns matching the given regular expression.
      *
      * @param  array|string  $pattern
-     * @param  \Closure|string  $replace
+     * @param  \Closure|string|string[]  $replace
      * @param  array|string  $subject
      * @param  int  $limit
      * @return string|string[]|null

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -732,7 +732,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Replace the patterns matching the given regular expression.
      *
      * @param  array|string  $pattern
-     * @param  \Closure|string  $replace
+     * @param  \Closure|string|string[]  $replace
      * @param  int  $limit
      * @return static
      */


### PR DESCRIPTION
preg_replace allows array of strings as $replace value. replaceMatches works also that way.